### PR TITLE
Allow retrieve token with a service account instead of user//password

### DIFF
--- a/test/get-token-test.js
+++ b/test/get-token-test.js
@@ -71,3 +71,39 @@ test('keycloakTokenRequest wrong url - connection refused', (t) => {
     t.end();
   });
 });
+
+test('keycloakTokenRequest - service account - should return a promise containing the access token', (t) => {
+  const baseUrl = 'http://127.0.0.1:9080/auth';
+  const settings = {
+    grant_type: 'client_credentials',
+    client_id: 'service_accountid',
+    client_secret: '28912097-138a-45e9-b2c2-d1faf4c0a86a',
+    realmName: 'demo'
+  };
+
+  let kca = keycloakTokenRequest(baseUrl, settings);
+
+  t.equal(kca instanceof Promise, true, 'should return a Promise');
+  kca.then((accessToken) => {
+    console.log(accessToken);
+    t.end();
+  });
+});
+
+test('keycloakTokenRequest - service account - failed login, wrong user creds', (t) => {
+  const baseUrl = 'http://127.0.0.1:9080/auth';
+  const settings = {
+    grant_type: 'client_credentials',
+    client_id: 'service_accountid',
+    client_secret: '28910197-138a-45e9-b2c2-d1faf4c0a86r',
+    realmName: 'demo'
+  };
+
+  let kca = keycloakTokenRequest(baseUrl, settings);
+
+  kca.catch((err) => {
+    t.equal(err.error_description, 'Invalid client secret', 'error description should be invalid client secret');
+    t.equal(err.error, 'unauthorized_client', 'error unauthorized_client');
+    t.end();
+  });
+});


### PR DESCRIPTION
Test cases have been added, but don't know how to create a service account automatically. This feature allows the user getting the token from a service account. this is useful if you don't have the admin username and password, but you have this service account with admin rights for that realm.