### PR TITLE
fix: change package maintainers to a list

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "author": {
     "name": "Red Hat, Inc."
   },
-  "maintainers": {
-    "name": "Lucas Holmquist",
-    "email": "lholmqui@redhat.com"
-  },
+  "maintainers": [
+    {
+      "name": "Lucas Holmquist",
+      "email": "lholmqui@redhat.com"
+    }
+  ],
   "engines": {
     "node": ">= 4.0.0"
   },


### PR DESCRIPTION
Hey there, I discovered an issue where I was trying to view this package on npm and I found the following.

![Screenshot 2019-07-05 at 15 56 23](https://user-images.githubusercontent.com/8656188/60730715-b29d8580-9f3d-11e9-85d5-3abe7fa294f1.png)

Looks like it should be a list https://docs.npmjs.com/files/package.json#people-fields-author-contributors

cheers.